### PR TITLE
feat: add ensemble averaging to simulation runs

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,17 +1,18 @@
 import logging
 from src.simulation import Simulation
 
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 def main():
-    logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
     logging.info("Starting main simulation")
     # Parameters
     N = 1000 # ensure this is even
-    f_cultural = 0.0
+    f_cultural = 0.5
     theta_list = [0, 4, 8, 12, 16]
     beta = 0.01
-    max_steps = 500
+    max_steps = 50
+    ensemble_size = 10
 
-    sim = Simulation(N, f_cultural, theta_list, beta, max_steps)
+    sim = Simulation(N, f_cultural, theta_list, beta, max_steps, ensemble_size)
     equilibria = sim.run_simulation()
     logging.info("Main simulation completed")
 

--- a/src/simulation.py
+++ b/src/simulation.py
@@ -5,15 +5,16 @@ from .agent import Agent
 from .game import Game
 
 class Simulation:
-    def __init__(self, N, f_cultural, theta_list, beta, max_steps):
+    def __init__(self, N, f_cultural, theta_list, beta, max_steps, ensemble_size):
         self.N = N
         self.f_cultural = f_cultural
         self.theta_list = theta_list
         self.beta = beta
         self.max_steps = max_steps
+        self.ensemble_size = ensemble_size
         self.population = [Agent(random.random() < f_cultural) for _ in range(N)]
-        self.equilibria = {}  # theta: fraction_T
-        logging.info(f"Initialized simulation with N={N}, f_cultural={f_cultural}, theta_list={theta_list}, beta={beta}, max_steps={max_steps}")
+        self.equilibria = {}  # theta: averaged fractions
+        logging.info(f"Initialized simulation with N={N}, f_cultural={f_cultural}, theta_list={theta_list}, beta={beta}, max_steps={max_steps}, ensemble_size={ensemble_size}")
 
     def initialize_for_theta(self, theta):
         if not self.equilibria:
@@ -31,25 +32,43 @@ class Simulation:
                     agent.strategy = random.choice(['T', 'I'])
             logging.info(f"Initialized strategies for theta {theta} based on closest previous theta {closest_theta} with T fraction {frac_dict['T']}")
 
+    def average_fractions(self, frac_list):
+        if not frac_list:
+            return {}
+        keys = frac_list[0].keys()
+        avg = {}
+        for k in keys:
+            avg[k] = sum(f[k] for f in frac_list) / len(frac_list)
+        return avg
+
     def run_simulation(self):
         os.makedirs('results', exist_ok=True)
         logging.info("Starting full simulation run")
         for theta in self.theta_list:
             logging.info(f"Processing theta {theta}")
             self.initialize_for_theta(theta)
-            game = Game(theta, self.beta, self.max_steps, self.population)
-            fractions = game.run()
-            self.equilibria[theta] = fractions
-            logging.info(f"Completed theta {theta}, final fractions: {fractions}")
-            # Save strategies
-            with open(f'results/strategy_theta_{theta}.txt', 'w') as f:
-                for agent in self.population:
-                    strategies = [str(s) for s, t in agent.history]
-                    f.write(' '.join(strategies) + '\n')
-            # Save payoffs
-            with open(f'results/payoff_theta_{theta}.txt', 'w') as f:
-                for agent in self.population:
-                    payoffs = [str(p) for p, t in agent.payoff_history]
-                    f.write(' '.join(payoffs) + '\n')
+            initial_strategies = [a.strategy for a in self.population]
+            ensemble_fractions = []
+            for i in range(self.ensemble_size):
+                # Reset strategies to initial
+                for a, s in zip(self.population, initial_strategies):
+                    a.strategy = s
+                game = Game(theta, self.beta, self.max_steps, self.population)
+                fractions = game.run()
+                ensemble_fractions.append(fractions)
+                # Save strategies
+                with open(f'results/strategy_theta_{theta}_ensemble_{i}.txt', 'w') as f:
+                    for agent in self.population:
+                        strategies = [str(s) for s in agent.history]
+                        f.write(' '.join(strategies) + '\n')
+                # Save payoffs
+                with open(f'results/payoff_theta_{theta}_ensemble_{i}.txt', 'w') as f:
+                    for agent in self.population:
+                        payoffs = [str(p) for p in agent.payoff_history]
+                        f.write(' '.join(payoffs) + '\n')
+            # Average fractions
+            averaged_fractions = self.average_fractions(ensemble_fractions)
+            self.equilibria[theta] = averaged_fractions
+            logging.info(f"Completed theta {theta}, averaged final fractions: {averaged_fractions}")
         logging.info(f"Simulation completed. Equilibria: {self.equilibria}")
         return self.equilibria


### PR DESCRIPTION
- Implemented ensemble_size parameter to run multiple simulations per theta value and average results
- Modified output files to include ensemble index for tracking individual runs
- Refactored strategy initialization to reset between ensemble runs for consistent starting conditions

closes #2 